### PR TITLE
Handle expired JWT tokens using custom AuthenticationEntryPoint

### DIFF
--- a/src/main/java/com/youssef/ecomera/auth/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/youssef/ecomera/auth/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.youssef.ecomera.auth.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.youssef.ecomera.common.exception.ErrorResponse;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.core.AuthenticationException;
+
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ErrorResponse error = ErrorResponse.of(
+                HttpStatus.UNAUTHORIZED.value(),
+                "Unauthorized",
+                "JWT token has expired",
+                request.getRequestURI()
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), error);
+    }
+}

--- a/src/main/java/com/youssef/ecomera/config/SecurityConfig.java
+++ b/src/main/java/com/youssef/ecomera/config/SecurityConfig.java
@@ -3,19 +3,20 @@ package com.youssef.ecomera.config;
 import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import com.youssef.ecomera.auth.security.JwtAuthenticationEntryPoint;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.logout.LogoutHandler;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
@@ -60,6 +61,7 @@ public class SecurityConfig {
     private final Filter jwtAuthFilter;
     private final AuthenticationProvider authenticationProvider;
     private final LogoutHandler logoutHandler;
+    private final  JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -90,6 +92,8 @@ public class SecurityConfig {
                         .addLogoutHandler(logoutHandler)
                         .logoutSuccessHandler((req, res, auth) -> SecurityContextHolder.clearContext())
                 )
+                .exceptionHandling(ex ->
+                        ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .build();
     }
 


### PR DESCRIPTION
## Summary

This PR adds a custom `AuthenticationEntryPoint` to properly handle expired JWT tokens at the Spring Security filter-chain level.

## Changes
- Added `JwtAuthenticationEntryPoint` under `auth/security`
- Wired the entry point into `SecurityConfig`
- Ensured expired JWTs return a consistent `401 Unauthorized` JSON response
- Reused the existing `ErrorResponse` contract for API consistency

## Why
Expired JWT exceptions are thrown before controller execution and were not reliably handled by `@RestControllerAdvice`.
Handling them via `AuthenticationEntryPoint` aligns with Spring Security best practices and ensures predictable API behavior.

## Result
- Expired tokens now return a clean `401` response
- No stack traces leaked
- Security concerns remain isolated from MVC exception handling
