### PR TITLE
ci(docker): run Docker workflow on PRs to master

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,13 @@
 name: Docker Release
 
 on:
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - "java/**"
+      - "pom.xml"
+      - "Dockerfile"
+      - ".github/workflows/docker-release.yml"
   push:
     branches: [ "master" ]
     paths:


### PR DESCRIPTION
## 📌 Pull Request: Update Docker Workflow to Run on PRs

### 📄 Summary
This PR updates the `docker-release.yml` workflow to also run on pull requests targeting the `master` branch. Previously, the workflow only executed on direct pushes and version tags, which meant Docker builds were skipped during PR validation.

### 🔹 Changes
- Added `pull_request` trigger for PRs into `master`.  
- Ensures Docker image build runs as part of PR checks.  
- Retains existing triggers for pushes, tags, and manual dispatch.  

### 📈 Impact
- ✅ Docker builds now run automatically on PRs, improving CI coverage.  
- ✅ Prevents surprises by validating Docker builds before merging into `master`.  
- ✅ Maintains release tagging and push behavior for versioned builds.  
