### PR TITLE
fix(ci): validate Docker builds on PRs without pushing images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     branches: [ "master" ]
     paths:
-      - "java/**"
+      - "src/**"
       - "pom.xml"
       - "Dockerfile"
       - ".github/workflows/docker-release.yml"
   push:
     branches: [ "master" ]
     paths:
-      - "java/**"
+      - "src/**"
       - "pom.xml"
       - "Dockerfile"
       - ".github/workflows/docker-release.yml"
@@ -36,6 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -48,7 +49,8 @@ jobs:
           images: ammysf/ecomera-backend
           tags: |
             type=ref,event=branch
-            type=sha,prefix={{branch}}-
+            type=ref,event=pr
+            type=sha,prefix=master-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
@@ -58,7 +60,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
- Build Docker image on PRs to validate Dockerfile
- Only push images on master merge or tags
- Conditional Docker Hub login (skip on PRs)
- Fix paths from java/** to src/**
- Add PR tag type for metadata