### PR TITLE
Feat/39 shopping cart functionality

### DIFF
--- a/src/main/java/com/youssef/ecomera/EcomeraApplication.java
+++ b/src/main/java/com/youssef/ecomera/EcomeraApplication.java
@@ -2,7 +2,9 @@ package com.youssef.ecomera;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class EcomeraApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/youssef/ecomera/domain/cart/controller/CartController.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/controller/CartController.java
@@ -1,0 +1,102 @@
+package com.youssef.ecomera.domain.cart.controller;
+
+import com.youssef.ecomera.domain.cart.dto.cart.CartCreateDto;
+import com.youssef.ecomera.domain.cart.dto.cart.CartDto;
+import com.youssef.ecomera.domain.cart.dto.cartitem.CartItemUpdateDto;
+import com.youssef.ecomera.domain.cart.service.CartService;
+import com.youssef.ecomera.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/cart")
+@RequiredArgsConstructor
+@Tag(name = "Cart", description = "Shopping cart management APIs")
+public class CartController {
+
+    private final CartService cartService;
+
+    @GetMapping
+    @Operation(summary = "Get authenticated user's cart", description = "Retrieve the current user's shopping cart")
+    @ApiResponse(responseCode = "200", description = "Cart retrieved successfully")
+    public ResponseEntity<CartDto> getMyCart(@AuthenticationPrincipal User user) {
+        CartDto cart = cartService.getMyCart(user.getId());
+        return ResponseEntity.ok(cart);
+    }
+
+//    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @GetMapping("/user/{userId}")
+    @Operation(summary = "Get cart by user ID", description = "Retrieve a user's shopping cart by their user ID")
+    @ApiResponse(responseCode = "200", description = "Cart retrieved successfully")
+    @ApiResponse(responseCode = "404", description = "Cart not found for user")
+    public ResponseEntity<CartDto> getCartByUserId(@PathVariable UUID userId) {
+        CartDto cart = cartService.getCartByUserId(userId);
+        return ResponseEntity.ok(cart);
+    }
+
+    @GetMapping("/{cartId}")
+    @Operation(summary = "Get cart by ID", description = "Retrieve a shopping cart by their ID")
+    @ApiResponse(responseCode = "200", description = "Cart retrieved successfully")
+    @ApiResponse(responseCode = "404", description = "Cart not found")
+    public ResponseEntity<CartDto> getCartById(@PathVariable UUID cartId) {
+        CartDto cart = cartService.getCartById(cartId);
+        return ResponseEntity.ok(cart);
+    }
+
+    @PostMapping("/items")
+    @Operation(summary = "Add item to cart", description = "Add a product to the shopping cart")
+    @ApiResponse(responseCode = "201", description = "Item added successfully")
+    @ApiResponse(responseCode = "404", description = "Product not found")
+    @ApiResponse(responseCode = "400", description = "Insufficient stock")
+    public ResponseEntity<CartDto> addToCart(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody CartCreateDto request) {
+        User user = (User) userDetails;
+        CartDto cart = cartService.addToCart(user.getId(), request);
+        return ResponseEntity.ok(cart);
+    }
+
+    @PatchMapping("/items/{cartItemId}")
+    @Operation(summary = "Update cart item", description = "Update the quantity of a cart item")
+    @ApiResponse(responseCode = "200", description = "Item updated successfully")
+    @ApiResponse(responseCode = "404", description = "Cart item not found")
+    @ApiResponse(responseCode = "400", description = "Insufficient stock")
+    public ResponseEntity<CartDto> updateCartItem(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID cartItemId,
+            @Valid @RequestBody CartItemUpdateDto request) {
+        User user = (User) userDetails;
+        CartDto cart = cartService.updateCartItem(user.getId(), cartItemId, request);
+        return ResponseEntity.ok(cart);
+    }
+
+    @DeleteMapping("/items/{cartItemId}")
+    @Operation(summary = "Remove cart item", description = "Remove an item from the cart")
+    @ApiResponse(responseCode = "200", description = "Item removed successfully")
+    @ApiResponse(responseCode = "404", description = "Cart item not found")
+    public ResponseEntity<CartDto> removeCartItem(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID cartItemId) {
+        User user = (User) userDetails;
+        CartDto cart = cartService.removeCartItem(user.getId(), cartItemId);
+        return ResponseEntity.ok(cart);
+    }
+
+    @DeleteMapping
+    @Operation(summary = "Clear cart", description = "Remove all items from the cart")
+    @ApiResponse(responseCode = "204", description = "Cart cleared successfully")
+    public ResponseEntity<Void> clearCart(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = (User) userDetails;
+        cartService.clearCart(user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/dto/cart/CartCreateDto.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/dto/cart/CartCreateDto.java
@@ -1,0 +1,25 @@
+package com.youssef.ecomera.domain.cart.dto.cart;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+@Schema(name = "CartCreateDto", description = "Request to add item to cart")
+public record CartCreateDto(
+
+        @NotNull(message = "Product ID is required")
+        @Schema(description = "Product ID to add", example = "123e4567-e89b-12d3-a456-426614174003")
+        UUID productId,
+
+        @NotNull(message = "Quantity is required")
+        @Min(value = 1, message = "Quantity must be at least 1")
+        @Max(value = 999, message = "Quantity cannot exceed 999")
+        @Schema(description = "Quantity to add", example = "2", minimum = "1", maximum = "999")
+        Integer quantity
+) {
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/dto/cart/CartDto.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/dto/cart/CartDto.java
@@ -1,0 +1,35 @@
+package com.youssef.ecomera.domain.cart.dto.cart;
+
+import com.youssef.ecomera.domain.cart.dto.cartitem.CartItemDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "Shopping cart response")
+public record CartDto(
+        @Schema(description = "Cart ID", example = "123e4567-e89b-12d3-a456-426614174000")
+        UUID id,
+
+        @Schema(description = "User ID who owns the cart", example = "123e4567-e89b-12d3-a456-426614174001")
+        UUID userId,
+
+        @Schema(description = "Items in the cart")
+        List<CartItemDto> cartItems,
+
+        @Schema(description = "Total price of all items", example = "159.97")
+        BigDecimal totalPrice,
+
+        @Schema(description = "Total number of items", example = "5")
+        Integer totalItems,
+
+        @Schema(description = "Cart expiration date", example = "2026-03-08T10:15:30")
+        LocalDateTime expiresAt,
+
+        @Schema(description = "Cart creation date", example = "2026-02-06T10:15:30")
+        LocalDateTime createdAt,
+
+        @Schema(description = "Cart last update date", example = "2026-02-06T10:15:30")
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/youssef/ecomera/domain/cart/dto/cartitem/CartItemDto.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/dto/cartitem/CartItemDto.java
@@ -1,0 +1,32 @@
+package com.youssef.ecomera.domain.cart.dto.cartitem;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Schema(description = "Cart item response")
+public record CartItemDto(
+        @Schema(description = "Cart item ID", example = "123e4567-e89b-12d3-a456-426614174002")
+        UUID id,
+
+        @Schema(description = "Product ID", example = "123e4567-e89b-12d3-a456-426614174003")
+        UUID productId,
+
+        @Schema(description = "Product title", example = "Wireless Headphones")
+        String productTitle,
+
+        @Schema(description = "Product image URL", example = "https://example.com/image.jpg")
+        String productImage,
+
+        @Schema(description = "Quantity", example = "2")
+        Integer quantity,
+
+        @Schema(description = "Unit price when added to cart", example = "79.99")
+        BigDecimal unitPrice,
+
+        @Schema(description = "Subtotal (quantity * unit price)", example = "159.98")
+        BigDecimal subtotal,
+
+        @Schema(description = "Current product stock", example = "15")
+        Integer availableStock
+) {}

--- a/src/main/java/com/youssef/ecomera/domain/cart/dto/cartitem/CartItemUpdateDto.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/dto/cartitem/CartItemUpdateDto.java
@@ -1,0 +1,16 @@
+package com.youssef.ecomera.domain.cart.dto.cartitem;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "Request to update cart item quantity")
+public record CartItemUpdateDto(
+        @NotNull(message = "Quantity is required")
+        @Min(value = 1, message = "Quantity must be at least 1")
+        @Max(value = 999, message = "Quantity cannot exceed 999")
+        @Schema(description = "New quantity", example = "3", minimum = "1", maximum = "999")
+        Integer quantity
+) {}
+

--- a/src/main/java/com/youssef/ecomera/domain/cart/entity/Cart.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/entity/Cart.java
@@ -1,0 +1,81 @@
+package com.youssef.ecomera.domain.cart.entity;
+
+import com.youssef.ecomera.common.audit.BaseEntity;
+import com.youssef.ecomera.user.entity.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.Audited;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Audited
+@Table(indexes = {
+        @Index(name = "idx_cart_user_id", columnList = "user_id")
+})
+public class Cart extends BaseEntity {
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @NotNull(message = "Cart must belong to a user")
+    private User user;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    // Helper methods for cart operations
+    public void addItem(CartItem item) {
+        cartItems.add(item);
+        item.setCart(this);
+        updateExpiration();
+    }
+
+    public void removeItem(CartItem item) {
+        cartItems.remove(item);
+        item.setCart(null);
+        updateExpiration();
+    }
+
+    public void clearItems() {
+        cartItems.clear();
+        updateExpiration();
+    }
+
+    public BigDecimal getTotalPrice() {
+        return cartItems.stream()
+                .map(CartItem::getSubtotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    public int getTotalItems() {
+        return cartItems.stream()
+                .mapToInt(CartItem::getQuantity)
+                .sum();
+    }
+
+    private void updateExpiration() {
+        this.expiresAt = LocalDateTime.now().plusDays(30);
+    }
+
+    @PrePersist
+    @PreUpdate
+    private void setExpiration() {
+        if (this.expiresAt == null) {
+            updateExpiration();
+        }
+    }
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/entity/CartItem.java
@@ -1,0 +1,84 @@
+package com.youssef.ecomera.domain.cart.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.youssef.ecomera.common.audit.BaseEntity;
+import com.youssef.ecomera.common.exception.BusinessException;
+import com.youssef.ecomera.domain.product.entity.Product;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.Audited;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Audited
+@Table(indexes = {
+        @Index(name = "idx_cart_item_cart_id", columnList = "cart_id"),
+        @Index(name = "idx_cart_item_product_id", columnList = "product_id"),
+})
+public class CartItem extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    @NotNull(message = "Cart item must belong to a cart")
+    @JsonBackReference
+    private Cart cart;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    @NotNull(message = "Cart item must reference a product")
+    private Product product;
+
+    @Column(nullable = false)
+    @Min(value = 1, message = "Quantity must be at least 1")
+    @Max(value = 999, message = "Quantity cannot exceed 999")
+    private Integer quantity;
+
+    @Column(name = "unit_price", nullable = false, precision = 10, scale = 2)
+    @NotNull(message = "Unit price is required")
+    @DecimalMin(value = "0.00", message = "Price must be positive")
+    private BigDecimal unitPrice;
+
+    // Business logic methods
+    public BigDecimal getSubtotal() {
+        return unitPrice.multiply(BigDecimal.valueOf(quantity));
+    }
+
+    public void increaseQuantity(int amount) {
+        if (amount < 1) {
+            throw new IllegalArgumentException("Amount must be positive");
+        }
+        this.quantity += amount;
+    }
+
+    public void decreaseQuantity(int amount) {
+        if (amount < 1) {
+            throw new IllegalArgumentException("Amount must be positive");
+        }
+        if (this.quantity - amount < 1) {
+            throw new IllegalArgumentException("Quantity cannot be less than 1");
+        }
+        this.quantity -= amount;
+    }
+
+    @PreUpdate
+    @PrePersist
+    private void validateStock() {
+        if (product != null && product.getStock() != null && quantity > product.getStock()) {
+            throw new BusinessException("Quantity exceeds available stock");
+        }
+    }
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/mapper/CartItemMapper.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/mapper/CartItemMapper.java
@@ -1,0 +1,19 @@
+package com.youssef.ecomera.domain.cart.mapper;
+
+import com.youssef.ecomera.common.mapper.BaseMapper;
+import com.youssef.ecomera.common.mapper.BaseMappingConfig;
+import com.youssef.ecomera.domain.cart.dto.cartitem.CartItemDto;
+import com.youssef.ecomera.domain.cart.entity.CartItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = BaseMappingConfig.class)
+public interface CartItemMapper extends BaseMapper<CartItem, CartItemDto> {
+    @Override
+    @Mapping(target = "productId", source = "product.id")
+    @Mapping(target = "productTitle", source = "product.title")
+    @Mapping(target = "productImage", source = "product.imageUrl")
+    @Mapping(target = "subtotal", expression = "java(entity.getSubtotal())")
+    @Mapping(target = "availableStock", source = "product.stock")
+    CartItemDto toDto(CartItem entity);
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/mapper/CartMapper.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/mapper/CartMapper.java
@@ -1,0 +1,17 @@
+package com.youssef.ecomera.domain.cart.mapper;
+
+import com.youssef.ecomera.common.mapper.BaseMapper;
+import com.youssef.ecomera.common.mapper.BaseMappingConfig;
+import com.youssef.ecomera.domain.cart.dto.cart.CartDto;
+import com.youssef.ecomera.domain.cart.entity.Cart;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = BaseMappingConfig.class, uses = CartItemMapper.class)
+public interface CartMapper extends BaseMapper<Cart, CartDto> {
+    @Override
+    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "totalPrice", expression = "java(entity.getTotalPrice())")
+    @Mapping(target = "totalItems", expression = "java(entity.getTotalItems())")
+    CartDto toDto(Cart entity);
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/repository/CartItemRepository.java
@@ -1,0 +1,13 @@
+package com.youssef.ecomera.domain.cart.repository;
+
+import com.youssef.ecomera.domain.cart.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CartItemRepository extends JpaRepository<CartItem, UUID> {
+    Optional<CartItem> findByCartIdAndProductId(UUID cartId, UUID productId);
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/repository/CartRepository.java
@@ -1,0 +1,23 @@
+package com.youssef.ecomera.domain.cart.repository;
+
+import com.youssef.ecomera.domain.cart.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, UUID> {
+    Optional<Cart> findByUserId(UUID userId);
+
+    @Query("SELECT c FROM Cart c LEFT JOIN FETCH c.cartItems ci LEFT JOIN FETCH ci.product WHERE c.user.id = :userId")
+    Optional<Cart> findByUserIdWithItems(UUID userId);
+
+    @Modifying
+    @Query("DELETE FROM Cart c WHERE c.expiresAt < :now")
+    void deleteExpiredCarts(LocalDateTime now);
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/service/CartService.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/service/CartService.java
@@ -1,0 +1,155 @@
+package com.youssef.ecomera.domain.cart.service;
+
+import com.youssef.ecomera.common.exception.BusinessException;
+import com.youssef.ecomera.common.exception.ResourceNotFoundException;
+import com.youssef.ecomera.domain.cart.dto.cart.CartCreateDto;
+import com.youssef.ecomera.domain.cart.dto.cart.CartDto;
+import com.youssef.ecomera.domain.cart.dto.cartitem.CartItemUpdateDto;
+import com.youssef.ecomera.domain.cart.entity.Cart;
+import com.youssef.ecomera.domain.cart.entity.CartItem;
+import com.youssef.ecomera.domain.cart.mapper.CartMapper;
+import com.youssef.ecomera.domain.cart.repository.CartItemRepository;
+import com.youssef.ecomera.domain.cart.repository.CartRepository;
+import com.youssef.ecomera.domain.product.entity.Product;
+import com.youssef.ecomera.domain.product.repository.ProductRepository;
+import com.youssef.ecomera.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ProductRepository productRepository;
+    private final CartMapper cartMapper;
+
+    @Transactional(readOnly = true)
+    public CartDto getMyCart(UUID userId) {
+        Cart cart = getOrCreateCart(userId);
+        return cartMapper.toDto(cart);
+    }
+
+    public CartDto getCartByUserId(UUID userId){
+        Optional<Cart> cart = cartRepository.findByUserId(userId);
+        if(cart.isEmpty()) {
+            throw new ResourceNotFoundException("Cart not found for user: " + userId);
+        }
+        return cartMapper.toDto(cart.get());
+    }
+
+    public CartDto getCartById(UUID cartId) {
+        Cart cart = cartRepository.findById(cartId)
+                .orElseThrow(() -> new ResourceNotFoundException("Cart not found with id: " + cartId));
+        return cartMapper.toDto(cart);
+    }
+
+    public CartDto addToCart(UUID userId, CartCreateDto request) {
+        Cart cart = getOrCreateCart(userId);
+        Product product = productRepository.findById(request.productId())
+                .orElseThrow(() -> new ResourceNotFoundException("Product not found"));
+
+        // Check stock availability
+        if (product.getStock() < request.quantity()) {
+            throw new BusinessException("Not enough stock available");
+        }
+
+        // Check if product already in cart
+        Optional<CartItem> existingItem = cartItemRepository
+                .findByCartIdAndProductId(cart.getId(), product.getId());
+
+        if (existingItem.isPresent()) {
+            CartItem item = existingItem.get();
+            int newQuantity = item.getQuantity() + request.quantity();
+
+            if (newQuantity > product.getStock()) {
+                throw new BusinessException("Not enough stock available");
+            }
+
+            item.setQuantity(newQuantity);
+            cartItemRepository.save(item);
+        } else {
+            CartItem newItem = CartItem.builder()
+                    .cart(cart)
+                    .product(product)
+                    .quantity(request.quantity())
+                    .unitPrice(product.getPrice())
+                    .build();
+            cart.addItem(newItem);
+        }
+
+        Cart savedCart = cartRepository.save(cart);
+        log.info("Added product {} to cart for user {}", product.getId(), userId);
+        return cartMapper.toDto(savedCart);
+    }
+
+    public CartDto updateCartItem(UUID userId, UUID cartItemId, CartItemUpdateDto request) {
+        Cart cart = getOrCreateCart(userId);
+
+        CartItem cartItem = cart.getCartItems().stream()
+                .filter(item -> item.getId().equals(cartItemId))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("Cart item not found"));
+
+        // Check stock
+        if (cartItem.getProduct().getStock() < request.quantity()) {
+            throw new BusinessException("Not enough stock available");
+        }
+
+        cartItem.setQuantity(request.quantity());
+        Cart savedCart = cartRepository.save(cart);
+        log.info("Updated cart item {} for user {}", cartItemId, userId);
+        return cartMapper.toDto(savedCart);
+    }
+
+    public CartDto removeCartItem(UUID userId, UUID cartItemId) {
+        Cart cart = getOrCreateCart(userId);
+
+        CartItem cartItem = cart.getCartItems().stream()
+                .filter(item -> item.getId().equals(cartItemId))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("Cart item not found"));
+
+        cart.removeItem(cartItem);
+        Cart savedCart = cartRepository.save(cart);
+        log.info("Removed cart item {} for user {}", cartItemId, userId);
+        return cartMapper.toDto(savedCart);
+    }
+
+    public void clearCart(UUID userId) {
+        Cart cart = getOrCreateCart(userId);
+        cart.clearItems();
+        cartRepository.save(cart);
+        log.info("Cleared cart for user {}", userId);
+    }
+
+    private Cart getOrCreateCart(UUID userId) {
+        return cartRepository.findByUserIdWithItems(userId)
+                .orElseGet(() -> {
+                    User user = User.builder()
+                            .id(userId)
+                            .build();
+                    Cart newCart = Cart.builder()
+                            .user(user)
+                            .build();
+                    return cartRepository.save(newCart);
+                });
+    }
+
+    // Scheduled task to clean expired carts
+    @Scheduled(cron = "0 0 2 * * ?") // Run daily at 2 AM
+    public void cleanExpiredCarts() {
+        cartRepository.deleteExpiredCarts(LocalDateTime.now());
+        log.info("Cleaned expired carts");
+    }
+}

--- a/src/main/java/com/youssef/ecomera/domain/order/controller/OrderController.java
+++ b/src/main/java/com/youssef/ecomera/domain/order/controller/OrderController.java
@@ -5,11 +5,11 @@ import com.youssef.ecomera.domain.order.dto.order.OrderDto;
 import com.youssef.ecomera.domain.order.dto.order.OrderUpdateDto;
 import com.youssef.ecomera.domain.order.dto.orderitem.OrderItemCreateDto;
 import com.youssef.ecomera.domain.order.service.OrderService;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import com.youssef.ecomera.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +17,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -30,11 +32,9 @@ public class OrderController {
     private final OrderService orderService;
 
     @Operation(summary = "Create a new order", description = "Creates a new order and returns the created resource.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Order created successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid order data"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @ApiResponse(responseCode = "201", description = "Order created successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid order data")
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
     @PostMapping
     public ResponseEntity<OrderDto> create(
             @Parameter(description = "Order creation payload") @Valid @RequestBody OrderCreateDto orderDto) {
@@ -43,12 +43,10 @@ public class OrderController {
     }
 
     @Operation(summary = "Update order status", description = "Updates the status of an existing order by ID.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Order updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid update data"),
-            @ApiResponse(responseCode = "404", description = "Order not found"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @ApiResponse(responseCode = "200", description = "Order updated successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid update data")
+    @ApiResponse(responseCode = "404", description = "Order not found")
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
     @PatchMapping("/{id}")
     public ResponseEntity<OrderDto> update(
             @Parameter(description = "Order UUID") @PathVariable UUID id,
@@ -57,11 +55,9 @@ public class OrderController {
     }
 
     @Operation(summary = "Delete order", description = "Deletes an order by ID.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "Order deleted successfully"),
-            @ApiResponse(responseCode = "404", description = "Order not found"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized")
-    })
+    @ApiResponse(responseCode = "204", description = "Order deleted successfully")
+    @ApiResponse(responseCode = "404", description = "Order not found")
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(
             @Parameter(description = "Order UUID") @PathVariable UUID id) {
@@ -70,10 +66,8 @@ public class OrderController {
     }
 
     @Operation(summary = "Get order by ID", description = "Fetches a single order by its UUID.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Order retrieved successfully"),
-            @ApiResponse(responseCode = "404", description = "Order not found")
-    })
+    @ApiResponse(responseCode = "200", description = "Order retrieved successfully")
+    @ApiResponse(responseCode = "404", description = "Order not found")
     @GetMapping("/{id}")
     public ResponseEntity<OrderDto> getById(
             @Parameter(description = "Order UUID") @PathVariable UUID id) {
@@ -81,9 +75,7 @@ public class OrderController {
     }
 
     @Operation(summary = "Get all orders", description = "Returns a paginated list of all orders.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Orders retrieved successfully")
-    })
+    @ApiResponse(responseCode = "200", description = "Orders retrieved successfully")
     @GetMapping
     public ResponseEntity<Page<OrderDto>> getAll(
             @Parameter(description = "Page number (0-based)", example = "0") @RequestParam(defaultValue = "0") int page,
@@ -93,10 +85,8 @@ public class OrderController {
     }
 
     @Operation(summary = "Get orders by status", description = "Returns orders filtered by status with pagination.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Orders retrieved successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid status provided")
-    })
+    @ApiResponse(responseCode = "200", description = "Orders retrieved successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid status provided")
     @GetMapping("/status")
     public ResponseEntity<Page<OrderDto>> getByStatus(
             @Parameter(description = "Order status", example = "PENDING") @RequestParam String status,
@@ -107,10 +97,8 @@ public class OrderController {
     }
 
     @Operation(summary = "Get orders by user", description = "Returns orders for a specific user with pagination.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Orders retrieved successfully"),
-            @ApiResponse(responseCode = "404", description = "User not found")
-    })
+    @ApiResponse(responseCode = "200", description = "Orders retrieved successfully")
+    @ApiResponse(responseCode = "404", description = "User not found")
     @GetMapping("/user")
     public ResponseEntity<Page<OrderDto>> getByUser(
             @Parameter(description = "User UUID") @RequestParam UUID userId,
@@ -121,11 +109,9 @@ public class OrderController {
     }
 
     @Operation(summary = "Add item to order", description = "Adds a new item to an existing order")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Item added successfully"),
-            @ApiResponse(responseCode = "404", description = "Order not found"),
-            @ApiResponse(responseCode = "400", description = "Cannot modify completed order")
-    })
+    @ApiResponse(responseCode = "200", description = "Item added successfully")
+    @ApiResponse(responseCode = "404", description = "Order not found")
+    @ApiResponse(responseCode = "400", description = "Cannot modify completed order")
     @PostMapping("/{orderId}/items")
     public ResponseEntity<OrderDto> addItem(
             @PathVariable UUID orderId,
@@ -148,5 +134,15 @@ public class OrderController {
             @PathVariable UUID itemId,
             @RequestParam Integer quantity) {
         return ResponseEntity.ok(orderService.updateItemQuantity(orderId, itemId, quantity));
+    }
+
+    @PostMapping("/checkout")
+    @Operation(summary = "Checkout", description = "Convert current cart into an order")
+    @ApiResponse(responseCode = "201", description = "Order created from cart")
+    @ApiResponse(responseCode = "400", description = "Cart is empty or insufficient stock")
+    public ResponseEntity<OrderDto> checkout(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = (User) userDetails;
+        OrderDto order = orderService.checkout(user.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(order);
     }
 }

--- a/src/main/java/com/youssef/ecomera/domain/order/service/OrderService.java
+++ b/src/main/java/com/youssef/ecomera/domain/order/service/OrderService.java
@@ -1,6 +1,9 @@
 package com.youssef.ecomera.domain.order.service;
 
 import com.youssef.ecomera.common.exception.ResourceNotFoundException;
+import com.youssef.ecomera.domain.cart.entity.Cart;
+import com.youssef.ecomera.domain.cart.entity.CartItem;
+import com.youssef.ecomera.domain.cart.repository.CartRepository;
 import com.youssef.ecomera.domain.order.dto.order.OrderCreateDto;
 import com.youssef.ecomera.domain.order.dto.order.OrderDto;
 import com.youssef.ecomera.domain.order.dto.order.OrderUpdateDto;
@@ -18,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.UUID;
 
@@ -35,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final CartRepository cartRepository;
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
     private final OrderMapper orderMapper;
@@ -149,7 +154,7 @@ public class OrderService {
     @Transactional
     public OrderDto addItemToOrder(UUID orderId, OrderItemCreateDto itemRequest) {
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new ResourceNotFoundException("Order", "id", orderId));
+                .orElseThrow(() -> new ResourceNotFoundException(Order.class.getSimpleName(), "id", orderId));
 
         // Validate order can be modified
         if (order.getStatus() == OrderStatus.SHIPPED ||
@@ -191,7 +196,7 @@ public class OrderService {
     @Transactional
     public OrderDto removeItemFromOrder(UUID orderId, UUID itemId) {
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new ResourceNotFoundException("Order", "id", orderId));
+                .orElseThrow(() -> new ResourceNotFoundException(Order.class.getSimpleName(), "id", orderId));
 
         // Validate order can be modified
         if (order.getStatus() == OrderStatus.SHIPPED ||
@@ -233,7 +238,7 @@ public class OrderService {
         }
 
         Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new ResourceNotFoundException("Order", "id", orderId));
+                .orElseThrow(() -> new ResourceNotFoundException(Order.class.getSimpleName(), "id", orderId));
 
         // Validate order can be modified
         if (order.getStatus() == OrderStatus.SHIPPED ||
@@ -271,6 +276,62 @@ public class OrderService {
         Order savedOrder = orderRepository.save(order);
         log.info("Order {} item {} quantity updated: {} -> {}", orderId, itemId, oldQuantity, newQuantity);
 
+        return orderMapper.toDto(savedOrder);
+    }
+
+    @Transactional
+    public OrderDto checkout(UUID userId) {
+        // 1. Fetch the cart
+        Cart cart = cartRepository.findByUserIdWithItems(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Cart not found for user: " + userId));
+
+        // 2. Guard against empty cart
+        if (cart.getCartItems() == null || cart.getCartItems().isEmpty()) {
+            throw new BusinessException("Cannot checkout with an empty cart");
+        }
+
+        // 3. Find the user
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
+
+        // 4. Build the order
+        Order order = Order.builder()
+                .user(user)
+                .status(OrderStatus.PENDING)
+                .totalPrice(BigDecimal.ZERO)
+                .build();
+
+        // 5. Convert cart items → order items
+        for (CartItem cartItem : cart.getCartItems()) {
+            Product product = cartItem.getProduct();
+
+            // Validate stock at checkout time
+            if (product.getStock() < cartItem.getQuantity()) {
+                throw new BusinessException(
+                        String.format("Insufficient stock for '%s'. Available: %d, In cart: %d",
+                                product.getTitle(), product.getStock(), cartItem.getQuantity())
+                );
+            }
+
+            OrderItem orderItem = OrderItem.builder()
+                    .product(product)
+                    .order(order)
+                    .quantity(cartItem.getQuantity())
+                    .unitPrice(cartItem.getUnitPrice()) // snapshot price at purchase time
+                    .build();
+
+            order.addItem(orderItem); // recalculates total automatically
+            product.setStock(product.getStock() - cartItem.getQuantity());
+        }
+
+        // 6. Save order
+        Order savedOrder = orderRepository.save(order);
+
+        // 7. Clear the cart
+        cart.clearItems();
+        cartRepository.save(cart);
+
+        log.info("Checkout completed for user {}. Order id: {}", userId, savedOrder.getId());
         return orderMapper.toDto(savedOrder);
     }
 }

--- a/src/main/java/com/youssef/ecomera/user/entity/User.java
+++ b/src/main/java/com/youssef/ecomera/user/entity/User.java
@@ -2,6 +2,7 @@ package com.youssef.ecomera.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.youssef.ecomera.common.audit.BaseEntity;
+import com.youssef.ecomera.domain.cart.entity.Cart;
 import com.youssef.ecomera.domain.order.entity.Order;
 import com.youssef.ecomera.auth.entity.Token;
 import com.youssef.ecomera.user.enums.Role;
@@ -70,6 +71,9 @@ public class User extends BaseEntity implements UserDetails {
     @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Order> orders;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private Cart cart;
 
     // Spring Security UserDetails methods
     @Override

--- a/src/main/resources/db/changelog/changes/v0.2.0/008-create-carts-table.xml
+++ b/src/main/resources/db/changelog/changes/v0.2.0/008-create-carts-table.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-5.0.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="008-create-carts-table" author="youssef" context="dev, prod" labels="v0.2.0, sprint-1">
+        <createTable tableName="cart">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_cart"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="expires_at" type="DATETIME"/>
+        </createTable>
+
+        <addUniqueConstraint columnNames="user_id" constraintName="uc_cart_user" tableName="cart"/>
+
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="cart" constraintName="FK_CART_ON_USER"
+                                 referencedColumnNames="id" referencedTableName="app_user"/>
+
+        <createIndex indexName="idx_cart_user_id" tableName="cart">
+            <column name="user_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v0.2.0/009-create-cart-items-table.xml
+++ b/src/main/resources/db/changelog/changes/v0.2.0/009-create-cart-items-table.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="009-create-cart-items-table" author="youssef" context="dev, prod" labels="v0.2.0, sprint-1">
+
+        <createTable tableName="cart_item">
+            <column name="id" type="UUID">
+                <constraints primaryKey="true" nullable="false" foreignKeyName="pk_cart_item"/>
+            </column>
+            <column name="cart_id" type="UUID">
+                <constraints nullable="false"
+                             foreignKeyName="fk_cart_item_cart"
+                             references="cart(id)"/>
+            </column>
+            <column name="product_id" type="UUID">
+                <constraints nullable="false"
+                             foreignKeyName="fk_cart_item_product"
+                             references="product(id)"/>
+            </column>
+            <column name="quantity" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="unit_price" type="DECIMAL(10,2)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="cart_item"
+                baseColumnNames="cart_id"
+                constraintName="FK_CART_ITEM_ON_CART"
+                referencedTableName="cart"
+                referencedColumnNames="id"
+                onDelete="CASCADE"/>
+
+        <addForeignKeyConstraint
+                baseTableName="cart_item"
+                baseColumnNames="product_id"
+                constraintName="FK_CART_ITEM_ON_PRODUCT"
+                referencedTableName="product"
+                referencedColumnNames="id"
+                onDelete="CASCADE"/>
+
+        <createIndex indexName="idx_cart_item_cart_id" tableName="cart_item">
+            <column name="cart_id"/>
+        </createIndex>
+
+        <createIndex indexName="idx_cart_item_product_id" tableName="cart_item">
+            <column name="product_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropTable tableName="cart_item"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v0.2.0/010-envers-audit-tables.xml
+++ b/src/main/resources/db/changelog/changes/v0.2.0/010-envers-audit-tables.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-5.0.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="010-envers-audit-tables.xml" author="youssef" context="dev, prod" labels="v0.2.0, sprint-1">
+        <createTable tableName="cart_aud">
+            <column name="rev" type="INT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_cart_aud"/>
+            </column>
+            <column name="revtype" type="SMALLINT"/>
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_cart_aud"/>
+            </column>
+            <column name="user_id" type="UUID"/>
+            <column name="expires_at" type="DATETIME"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseColumnNames="rev" baseTableName="cart_aud" constraintName="FK_CART_AUD_ON_REV"
+                                 referencedColumnNames="rev" referencedTableName="revinfo"/>
+
+        <createTable tableName="cart_item_aud">
+            <column name="rev" type="INT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_cart_item_aud"/>
+            </column>
+            <column name="revtype" type="SMALLINT"/>
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_cart_item_aud"/>
+            </column>
+            <column name="cart_id" type="UUID"/>
+            <column name="product_id" type="UUID"/>
+            <column name="quantity" type="INT"/>
+            <column name="unit_price" type="DECIMAL(10,2)"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseColumnNames="rev" baseTableName="cart_item_aud"
+                                 constraintName="FK_CART_ITEM_AUD_ON_REV"
+                                 referencedColumnNames="rev" referencedTableName="revinfo"/>
+
+        <rollback>
+            <dropTable tableName="cart_aud"/>
+            <dropTable tableName="cart_item_aud"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -3,7 +3,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-5.0.xsd"
         objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
 
     <include file="db/changelog/changes/v0.1.0/001-create-users-table.xml"/>
@@ -17,5 +17,14 @@
     <changeSet id="tag-v0.1.0" author="youssef" context="dev, prod" labels="v0.1.0, sprint-0">
         <tagDatabase tag="v0.1.0"/>
     </changeSet>
+
+    <include file="/db/changelog/changes/v0.2.0/008-create-carts-table.xml"/>
+    <include file="/db/changelog/changes/v0.2.0/009-create-cart-items-table.xml"/>
+    <include file="/db/changelog/changes/v0.2.0/010-envers-audit-tables.xml"/>
+
+    <changeSet id="tag-v0.2.0" author="youssef" context="dev, prod" labels="v0.2.0, sprint-1">
+        <tagDatabase tag="v0.2.0"/>
+    </changeSet>
+
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
Implements the cart domain and checkout flow

## Changes

### Cart (new domain)
- Full CRUD , add, update, remove item, clear cart, fetch cart
- Quantity merge when adding an existing product
- JWT-authenticated endpoints via @AuthenticationPrincipal
- Liquibase migrations 008–011 including Envers audit tables and FK cascade fix

### Checkout (order domain extension)
- POST /api/v1/orders/checkout converts user cart into a PENDING order
- Stock validated at checkout time
- Price snapshotted from cart to guard against price changes mid-session
- Cart cleared automatically after successful checkout

## Tested
- [x] Add new item to cart
- [x] Add duplicate item → quantity merges
- [x] Update item quantity
- [x] Remove item
- [x] Clear cart
- [x] Delete product → cart item removed automatically
- [x] Checkout happy path
- [x] Checkout with empty cart → 400
- [x] Checkout with insufficient stock → 400