### PR TITLE
feat(redis): Implement Redis caching for cart and product services

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,7 +46,7 @@ liquibase:
 
 redis:
   - changed-files:
-      - any-glob-to-any-file: [ "src/main/java/**/cache/**", "src/main/resources/redis/**", "redis.conf", "docker/redis/**" ]
+      - any-glob-to-any-file: [ "src/main/java/**/cache/**", "src/main/resources/redis/**", "src/main/java/**/config/Redis*.java", "src/main/java/**/config/*Cache*.java", "redis.conf", "docker/redis/**" ]
   - title: [ "redis", "cache" ]
   - body: [ "redis", "cache", "in-memory" ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
+    command: redis-server --appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/src/main/java/com/youssef/ecomera/config/RedisConfig.java
+++ b/src/main/java/com/youssef/ecomera/config/RedisConfig.java
@@ -1,0 +1,82 @@
+package com.youssef.ecomera.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.youssef.ecomera.domain.cart.dto.cart.CartDto;
+import com.youssef.ecomera.domain.product.dto.ProductDto;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableCaching
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+
+        // Products cache — knows exactly it's ProductDto
+        RedisCacheConfiguration productsConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(1))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper(), ProductDto.class)));
+
+        // Cart cache — knows exactly it's CartDto
+        RedisCacheConfiguration cartConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper(), CartDto.class)));
+
+        Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+        cacheConfigs.put("cart", cartConfig);
+        cacheConfigs.put("products", productsConfig);
+        cacheConfigs.put("products-page", productsConfig);
+        cacheConfigs.put("products-search", productsConfig);
+        cacheConfigs.put("products-category", productsConfig);
+        cacheConfigs.put("products-title", productsConfig);
+
+        return RedisCacheManager.builder(connectionFactory)
+                .withInitialCacheConfigurations(cacheConfigs)
+                .build();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    private ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+}

--- a/src/main/java/com/youssef/ecomera/domain/cart/service/CartService.java
+++ b/src/main/java/com/youssef/ecomera/domain/cart/service/CartService.java
@@ -15,6 +15,8 @@ import com.youssef.ecomera.domain.product.repository.ProductRepository;
 import com.youssef.ecomera.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,47 +37,48 @@ public class CartService {
     private final CartMapper cartMapper;
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "cart", key = "#userId")
     public CartDto getMyCart(UUID userId) {
+        log.debug("Cache miss — fetching cart for user {}", userId);
         Cart cart = getOrCreateCart(userId);
         return cartMapper.toDto(cart);
     }
 
-    public CartDto getCartByUserId(UUID userId){
+    // Admin lookup — not cached, low traffic
+    public CartDto getCartByUserId(UUID userId) {
         Optional<Cart> cart = cartRepository.findByUserId(userId);
-        if(cart.isEmpty()) {
+        if (cart.isEmpty()) {
             throw new ResourceNotFoundException("Cart not found for user: " + userId);
         }
         return cartMapper.toDto(cart.get());
     }
 
+    // Admin lookup — not cached, low traffic
     public CartDto getCartById(UUID cartId) {
         Cart cart = cartRepository.findById(cartId)
                 .orElseThrow(() -> new ResourceNotFoundException("Cart not found with id: " + cartId));
         return cartMapper.toDto(cart);
     }
 
+    @CacheEvict(value = "cart", key = "#userId")
     public CartDto addToCart(UUID userId, CartCreateDto request) {
         Cart cart = getOrCreateCart(userId);
         Product product = productRepository.findById(request.productId())
                 .orElseThrow(() -> new ResourceNotFoundException("Product not found"));
 
-        // Check stock availability
         if (product.getStock() < request.quantity()) {
             throw new BusinessException("Not enough stock available");
         }
 
-        // Check if product already in cart
         Optional<CartItem> existingItem = cartItemRepository
                 .findByCartIdAndProductId(cart.getId(), product.getId());
 
         if (existingItem.isPresent()) {
             CartItem item = existingItem.get();
             int newQuantity = item.getQuantity() + request.quantity();
-
             if (newQuantity > product.getStock()) {
                 throw new BusinessException("Not enough stock available");
             }
-
             item.setQuantity(newQuantity);
             cartItemRepository.save(item);
         } else {
@@ -89,32 +92,31 @@ public class CartService {
         }
 
         Cart savedCart = cartRepository.save(cart);
-        log.info("Added product {} to cart for user {}", product.getId(), userId);
+        log.info("Added product {} to cart for user {} — cache evicted", product.getId(), userId);
         return cartMapper.toDto(savedCart);
     }
 
+    @CacheEvict(value = "cart", key = "#userId")
     public CartDto updateCartItem(UUID userId, UUID cartItemId, CartItemUpdateDto request) {
         Cart cart = getOrCreateCart(userId);
-
         CartItem cartItem = cart.getCartItems().stream()
                 .filter(item -> item.getId().equals(cartItemId))
                 .findFirst()
                 .orElseThrow(() -> new ResourceNotFoundException("Cart item not found"));
 
-        // Check stock
         if (cartItem.getProduct().getStock() < request.quantity()) {
             throw new BusinessException("Not enough stock available");
         }
 
         cartItem.setQuantity(request.quantity());
         Cart savedCart = cartRepository.save(cart);
-        log.info("Updated cart item {} for user {}", cartItemId, userId);
+        log.info("Updated cart item {} for user {} — cache evicted", cartItemId, userId);
         return cartMapper.toDto(savedCart);
     }
 
+    @CacheEvict(value = "cart", key = "#userId")
     public CartDto removeCartItem(UUID userId, UUID cartItemId) {
         Cart cart = getOrCreateCart(userId);
-
         CartItem cartItem = cart.getCartItems().stream()
                 .filter(item -> item.getId().equals(cartItemId))
                 .findFirst()
@@ -122,32 +124,28 @@ public class CartService {
 
         cart.removeItem(cartItem);
         Cart savedCart = cartRepository.save(cart);
-        log.info("Removed cart item {} for user {}", cartItemId, userId);
+        log.info("Removed cart item {} for user {} — cache evicted", cartItemId, userId);
         return cartMapper.toDto(savedCart);
     }
 
+    @CacheEvict(value = "cart", key = "#userId")
     public void clearCart(UUID userId) {
         Cart cart = getOrCreateCart(userId);
         cart.clearItems();
         cartRepository.save(cart);
-        log.info("Cleared cart for user {}", userId);
+        log.info("Cleared cart for user {} — cache evicted", userId);
     }
 
     private Cart getOrCreateCart(UUID userId) {
         return cartRepository.findByUserIdWithItems(userId)
                 .orElseGet(() -> {
-                    User user = User.builder()
-                            .id(userId)
-                            .build();
-                    Cart newCart = Cart.builder()
-                            .user(user)
-                            .build();
+                    User user = User.builder().id(userId).build();
+                    Cart newCart = Cart.builder().user(user).build();
                     return cartRepository.save(newCart);
                 });
     }
 
-    // Scheduled task to clean expired carts
-    @Scheduled(cron = "0 0 2 * * ?") // Run daily at 2 AM
+    @Scheduled(cron = "0 0 2 * * ?")
     public void cleanExpiredCarts() {
         cartRepository.deleteExpiredCarts(LocalDateTime.now());
         log.info("Cleaned expired carts");

--- a/src/main/java/com/youssef/ecomera/domain/product/service/ProductService.java
+++ b/src/main/java/com/youssef/ecomera/domain/product/service/ProductService.java
@@ -11,6 +11,10 @@ import com.youssef.ecomera.domain.product.mapper.ProductMapper;
 import com.youssef.ecomera.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,48 +35,70 @@ public class ProductService {
     private final ProductMapper productMapper;
 
     @Transactional
+    @Caching(
+            put = @CachePut(value = "products", key = "#result.id"),
+            evict = {
+                    @CacheEvict(value = "products-page", allEntries = true),
+                    @CacheEvict(value = "products-search", allEntries = true),
+                    @CacheEvict(value = "products-category", allEntries = true),
+                    @CacheEvict(value = "products-title", allEntries = true)
+            }
+    )
     public ProductDto saveProduct(ProductCreateDto dto) {
         Product product = productMapper.toEntity(dto);
         Product savedProduct = productRepository.save(product);
-
         log.info("Product created: {} - {}", savedProduct.getId(), savedProduct.getTitle());
         return productMapper.toDto(savedProduct);
     }
 
     @Transactional
+    @Caching(
+            put = @CachePut(value = "products", key = "#id"),
+            evict = {
+                    @CacheEvict(value = "products-page", allEntries = true),
+                    @CacheEvict(value = "products-search", allEntries = true),
+                    @CacheEvict(value = "products-category", allEntries = true),
+                    @CacheEvict(value = "products-title", allEntries = true)
+            }
+    )
     public ProductDto update(UUID id, ProductUpdateDto dto) {
         Product product = productRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(getClass().getSimpleName(), "id", id));
-
         productMapper.updateEntityFromDto(dto, product);
         Product updated = productRepository.save(product);
-
         log.info("Product updated: {}", id);
         return productMapper.toDto(updated);
     }
 
+    @Cacheable(value = "products", key = "#id")
     public ProductDto getProductById(UUID id) {
+        log.debug("Cache miss fetching product {} from DB", id);
         return productRepository.findById(id)
                 .map(productMapper::toDto)
                 .orElseThrow(() -> new ResourceNotFoundException(getClass().getSimpleName(), "id", id));
     }
 
+    @Cacheable(value = "products-page", key = "#page + '-' + #size + '-' + #sortBy + '-' + #direction")
     public Page<ProductDto> getAllProducts(int page, int size, String sortBy, String direction) {
+        log.debug("Cache miss fetching all products from DB");
         Sort sort = direction.equalsIgnoreCase("asc")
                 ? Sort.by(sortBy).ascending()
                 : Sort.by(sortBy).descending();
-
         Pageable pageable = PageRequest.of(page, size, sort);
-        Page<Product> products = productRepository.findAll(pageable);
-
-        return products.map(productMapper::toDto);
+        return productRepository.findAll(pageable).map(productMapper::toDto);
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "products", key = "#id"),
+            @CacheEvict(value = "products-page", allEntries = true),
+            @CacheEvict(value = "products-search", allEntries = true),
+            @CacheEvict(value = "products-category", allEntries = true),
+            @CacheEvict(value = "products-title", allEntries = true)
+    })
     public void deleteProductById(UUID id) {
         Product product = productRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(getClass().getSimpleName(), "id", id));
-
         productRepository.delete(product);
         log.info("Product deleted: {}", id);
     }
@@ -84,56 +110,46 @@ public class ProductService {
     public long countProductsByCategory(String category) {
         CategoryType categoryType = CategoryType.fromString(category)
                 .orElseThrow(() -> new BusinessException("Invalid category: " + category));
-
         return productRepository.countProductsByCategory(categoryType);
     }
 
+    @Cacheable(value = "products-search", key = "#query + '-' + #pageable.pageNumber + '-' + #pageable.pageSize")
     public Page<ProductDto> searchProducts(String query, Pageable pageable) {
         if (query == null || query.trim().isEmpty()) {
             throw new BusinessException("Search query cannot be empty");
         }
-
-        Page<Product> products = productRepository.searchProducts(query, pageable);
-        return products.map(productMapper::toDto);
+        log.debug("Cache miss - searching products for query: {}", query);
+        return productRepository.searchProducts(query, pageable).map(productMapper::toDto);
     }
 
+    @Cacheable(value = "products-category", key = "#category + '-' + #pageable.pageNumber + '-' + #pageable.pageSize")
     public Page<ProductDto> getProductsByCategory(String category, Pageable pageable) {
         CategoryType categoryType = CategoryType.fromString(category)
                 .orElseThrow(() -> new BusinessException("Invalid category: " + category));
-
-        log.info("Searching products by category: {}", categoryType);
-        Page<Product> products = productRepository.findByCategory(categoryType, pageable);
-
-        return products.map(productMapper::toDto);
+        log.info("Cache miss - fetching products by category: {}", categoryType);
+        return productRepository.findByCategory(categoryType, pageable).map(productMapper::toDto);
     }
 
+    @Cacheable(value = "products-title", key = "#title")
     public ProductDto getProductByTitle(String title) {
         if (title == null || title.trim().isEmpty()) {
             throw new BusinessException("Title cannot be null or empty");
         }
-
+        log.debug("Cache miss - fetching product by title: {}", title);
         Product product = productRepository.findByTitle(title);
         if (product == null) {
             throw new ResourceNotFoundException(getClass().getSimpleName(), "title", title);
         }
-
         return productMapper.toDto(product);
     }
 
-    public Page<ProductDto> getProductsByPriceBetweenRange(
-            BigDecimal minPrice,
-            BigDecimal maxPrice,
-            Pageable pageable) {
-
+    public Page<ProductDto> getProductsByPriceBetweenRange(BigDecimal minPrice, BigDecimal maxPrice, Pageable pageable) {
         if (minPrice == null || maxPrice == null) {
             throw new BusinessException("Price range cannot be null");
         }
-
         if (minPrice.compareTo(maxPrice) > 0) {
             throw new BusinessException("Min price cannot be greater than max price");
         }
-
-        Page<Product> products = productRepository.findByPriceBetween(minPrice, maxPrice, pageable);
-        return products.map(productMapper::toDto);
+        return productRepository.findByPriceBetween(minPrice, maxPrice, pageable).map(productMapper::toDto);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,9 +42,21 @@ spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 
 # ============================================
-# Redis - Disabled (Sprint 1)
+# Redis Configuration for Caching and Session Management
 # ============================================
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+spring.cache.type=redis
+spring.cache.redis.time-to-live=3600000
+spring.cache.redis.cache-null-values=false
+
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASSWORD:}
+spring.data.redis.username=${REDIS_USERNAME:}
+spring.data.redis.timeout=2000ms
+spring.data.redis.lettuce.pool.max-active=10
+spring.data.redis.lettuce.pool.max-idle=5
+spring.data.redis.lettuce.pool.min-idle=1
+spring.data.redis.lettuce.pool.max-wait=1000ms
 
 # ============================================
 # Spring Security Defaults (local/test only)


### PR DESCRIPTION
## Summary
Implements Redis caching layer for product catalog and user cart to reduce 
database load and improve response times. Closes #18

## Changes

### Infrastructure
- Add `RedisConfig` with `RedisCacheManager`, per-cache TTL configuration
  and `Jackson2JsonRedisSerializer` with typed serialization per cache
- Add `CachedPage<T>` wrapper DTO in `common/dto` to handle `Page` 
  serialization cleanly (avoids `PageImpl` deserialization issues)
- Add `PageImplMixin` in `config` for Jackson deserialization support
- Add `@EnableCaching` in `RedisConfig`
- Add `@EnableScheduling` in main class for cart cleanup scheduler
- Update `docker-compose.yml` — add `redis-server --appendonly yes` for persistence

### Product Caching
- `@Cacheable` on `getProductById()` - TTL 1 hour
- `@Cacheable` on `getProductByTitle()` - TTL 30 minutes
- `@Cacheable` on `getAllProducts()` - TTL 30 minutes via `CachedPage`
- `@Cacheable` on `searchProducts()` - TTL 30 minutes via `CachedPage`
- `@Cacheable` on `getProductsByCategory()`- TTL 30 minutes via `CachedPage`
- `@CachePut` + `@CacheEvict` on `saveProduct()` - evicts all paginated caches
- `@CachePut` + `@CacheEvict` on `update()` - evicts all paginated caches
- `@CacheEvict` on `deleteProductById()` - evicts all related caches

### Cart Caching
- `@Cacheable` on `getMyCart()` - TTL 30 minutes, key by userId
- `@CacheEvict` on `addToCart()`, `updateCartItem()`, `removeCartItem()`, `clearCart()`
- Cart cache evicted on every mutation to ensure consistency

## Cache Configuration
| Cache | Type | TTL |
|---|---|---|
| products | ProductDto | 1 hour |
| products-title | ProductDto | 30 min |
| products-page | CachedPage<ProductDto> | 30 min |
| products-search | CachedPage<ProductDto> | 30 min |
| products-category | CachedPage<ProductDto> | 30 min |
| cart | CartDto | 30 min |

## Tested
- [x] First call → cache miss, DB hit (log appears)
- [x] Second call → cache hit, no DB query (no log)
- [x] Add product → paginated caches evicted, new product visible
- [x] Update product → cache updated, paginated caches evicted
- [x] Delete product → all related caches evicted
- [x] Add to cart → cart cache evicted, fresh data on next fetch
- [x] Redis keys visible via `redis-cli KEYS *`
- [x] FLUSHALL resolves stale type mismatch between deploys

## Notes
- `Page<T>` cannot be serialized directly by Jackson — solved with `CachedPage<T>` 
  wrapper that stores content + pagination metadata as plain fields
- `Jackson2JsonRedisSerializer<SpecificDto.class>` used per cache instead of 
  `Object.class` to avoid `LinkedHashMap` deserialization issue
- Always run `redis-cli FLUSHALL` after serialization config changes to avoid 
  stale type conflicts !